### PR TITLE
Map Group call in KISSMetrics

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,6 +136,17 @@ KISSmetrics.prototype.alias = function(alias) {
 };
 
 /**
+ * Group.
+ *
+ * @param {Group} to
+ */
+
+KISSmetrics.prototype.group = function(group) {
+  console.log('group called', group);
+  push('set', prefix('Group', group.traits()));
+};
+
+/**
  * Completed order.
  *
  * @param {Track} track

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -254,6 +254,30 @@ describe('KISSmetrics', function() {
       });
     });
 
+    describe('#group', function() {
+      beforeEach(function() {
+        analytics.stub(window._kmq, 'push');
+      });
+
+      it('should send a group information', function() {
+        analytics.group('new', {
+          name: 'Initech',
+          industry: 'Technology',
+          employees: 329,
+          plan: 'enterprise',
+          'total billed': 830
+        });
+        analytics.called(window._kmq.push, ['set', {
+          'Group - name': 'Initech',
+          'Group - industry': 'Technology',
+          'Group - employees': 329,
+          'Group - plan': 'enterprise',
+          'Group - total billed': 830,
+          'Group - id': 'new'
+        }]);
+      });
+    });
+
     describe('ecommerce', function() {
       beforeEach(function() {
         analytics.stub(window._kmq, 'push');


### PR DESCRIPTION
Ref https://github.com/segmentio/integration-kissmetrics/pull/9

This will now forward group calls to KissMetrics.

See the group-basic.json for a full example, but basically we send all
traits as a property with the `Group' prefix
