### PR TITLE
Always use the provided page URL and referrer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,12 @@ KISSmetrics.prototype.loaded = function() {
  */
 
 KISSmetrics.prototype.page = function(page) {
-  if (!window.KM_SKIP_PAGE_VIEW) window.KM.pageView();
+  if (!window.KM_SKIP_PAGE_VIEW) {
+    push('record', 'Page View', {
+      'Viewed URL': page.url(),
+      Referrer: page.referrer() || 'Direct'
+    });
+  }
   this.trackPage(page);
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -87,22 +87,21 @@ describe('KISSmetrics', function() {
         window.KM_SKIP_PAGE_VIEW = 1;
       });
 
-      it('should record normal kissmetrics page views when the option is set', function() {
-        window.KM_SKIP_PAGE_VIEW = false;
-        analytics.page();
-        analytics.didNotCall(window._kmq.push);
-      });
-
       it('should call `KM.pageView()` when KM_SKIP_PAGE_VIEW is not set', function() {
         window.KM_SKIP_PAGE_VIEW = false;
         analytics.page();
-        analytics.calledOnce(window.KM.pageView);
+        analytics.called(window._kmq.push, ['record', 'Page View', {
+          'Viewed URL': window.location.href,
+          Referrer: document.referrer || 'Direct'
+        }]);
       });
 
       it('should not call `KM.pageView()` when KM_SKIP_PAGE_VIEW is set', function() {
+        kissmetrics.options.trackNamedPages = false;
+        kissmetrics.options.trackCategoryPages = false;
         window.KM_SKIP_PAGE_VIEW = 1;
         analytics.page();
-        analytics.didNotCall(window.KM.pageView);
+        analytics.didNotCall(window._kmq.push);
       });
 
       it('should track named pages by default', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -87,16 +87,34 @@ describe('KISSmetrics', function() {
         window.KM_SKIP_PAGE_VIEW = 1;
       });
 
-      it('should call `KM.pageView()` when KM_SKIP_PAGE_VIEW is not set', function() {
-        window.KM_SKIP_PAGE_VIEW = false;
-        analytics.page();
-        analytics.called(window._kmq.push, ['record', 'Page View', {
-          'Viewed URL': window.location.href,
-          Referrer: document.referrer || 'Direct'
-        }]);
+      describe('when KM_SKIP_PAGE_VIEW is false', function() {
+        beforeEach(function() {
+          window.KM_SKIP_PAGE_VIEW = false;
+        });
+
+        it('should send a Page View event with the window URL and referrer', function() {
+          analytics.page();
+          analytics.called(window._kmq.push, ['record', 'Page View', {
+            'Viewed URL': window.location.href,
+            Referrer: document.referrer || 'Direct'
+          }]);
+        });
+
+        describe('when a custom page is provided', function() {
+          it('should send a Page View event with the page URL and referrer', function() {
+            analytics.page('Name', {
+              url: 'http://foo.com/',
+              referrer: 'http://bar.com/'
+            });
+            analytics.called(window._kmq.push, ['record', 'Page View', {
+              'Viewed URL': 'http://foo.com/',
+              Referrer: 'http://bar.com/'
+            }]);
+          });
+        });
       });
 
-      it('should not call `KM.pageView()` when KM_SKIP_PAGE_VIEW is set', function() {
+      it('should not send a Page View event on a call to page() when KM_SKIP_PAGE_VIEW is set', function() {
         kissmetrics.options.trackNamedPages = false;
         kissmetrics.options.trackCategoryPages = false;
         window.KM_SKIP_PAGE_VIEW = 1;


### PR DESCRIPTION
We've had a customer wanting to track AJAX page loads. They pass details to `page()`, but our internal `KM.pageView()` function records a _Page View_ event with the window URL as a property rather than the URL of the specified page.

The `KM.pageView()` function is defined [as follows](https://github.com/kissmetrics/tracker/blob/09ff5edfa9f4e0b8b950286cde89060399ad4501/src/page_view.js#L27-L33):

``` javascript
KM.pageView = function() {
  window._kmq.push(['record', 'Page View', {
    'Viewed URL': KM.u(),
    'Referrer': KM.rf()  || 'Direct'
  }]);
}
```

This PR inlines and then modifies the page view tracking code so that we send the correct details.

cc @salomon
