### PR TITLE
Adjust initialization behavior

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,6 @@ var extend = require('extend');
  */
 
 var KISSmetrics = module.exports = integration('KISSmetrics')
-  .assumesPageview()
   .global('KM')
   .global('_kmil')
   .global('_kmq')
@@ -41,19 +40,12 @@ exports.isMobile = navigator.userAgent.match(/Android/i)
  * Initialize.
  *
  * http://support.kissmetrics.com/apis/javascript
- *
- * @param {Object} page
  */
 
-KISSmetrics.prototype.initialize = function(page) {
-  var self = this;
+KISSmetrics.prototype.initialize = function() {
   window._kmq = window._kmq || [];
   if (exports.isMobile) push('set', { 'Mobile Session': 'Yes' });
-
-  this.load('library', function() {
-    self.trackPage(page);
-    self.ready();
-  });
+  this.load('library', this.ready);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ exports.isMobile = navigator.userAgent.match(/Android/i)
 
 KISSmetrics.prototype.initialize = function(page) {
   var self = this;
-  window._kmq = [];
+  window._kmq = window._kmq || [];
   if (exports.isMobile) push('set', { 'Mobile Session': 'Yes' });
 
   this.load('library', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,7 +37,6 @@ describe('KISSmetrics', function() {
 
   it('should have the right settings', function() {
     analytics.compare(KISSmetrics, integration('KISSmetrics')
-      .assumesPageview()
       .global('KM')
       .global('_kmil')
       .global('_kmq')
@@ -51,7 +50,6 @@ describe('KISSmetrics', function() {
     beforeEach(function() {
       analytics.stub(kissmetrics, 'load');
       analytics.initialize();
-      analytics.page();
     });
 
     describe('#initialize', function() {
@@ -71,7 +69,6 @@ describe('KISSmetrics', function() {
     beforeEach(function(done) {
       analytics.once('ready', done);
       analytics.initialize();
-      analytics.page();
     });
 
     it('should create window.KM', function() {


### PR DESCRIPTION
This makes two changes to initialization for the integration:
- `window._kmq` is not clobbered if it already exists, e.g. on account of another tracking snippet; and
- `assumesPageview` is dropped to support tracking of events or properties before or without a `page` call.
