### PR TITLE
Discard nested undefined values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -232,7 +232,7 @@ function clean(obj) {
   for (var k in obj) {
     if (obj.hasOwnProperty(k)) {
       var value = obj[k];
-      if (value === null) continue;
+      if (value === null || typeof value === 'undefined') continue;
 
       // convert date to unix
       if (is.date(value)) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -282,6 +282,19 @@ describe('KISSmetrics', function() {
           'event - glenn.coco': '1,2,3'
         }]);
       });
+
+      it('should discard null and undefined values inside nested objects', function() {
+        analytics.track('event', {
+          foo: 'bar',
+          xy: null,
+          baz: 'quux',
+          zzy: undefined
+        });
+        analytics.called(window._kmq.push, ['record', 'event', {
+          'event - foo': 'bar',
+          'event - baz': 'quux'
+        }]);
+      });
     });
 
     describe('#alias', function() {


### PR DESCRIPTION
This fixes a bug in the `clean` function. `undefined` values would [pass through](https://github.com/kissmetrics/analytics.js-integration-kissmetrics/blob/757929883b1c5bef070ed1e569ab687849f473d8/lib/index.js#L235) the existence test, and [ultimately fail](https://github.com/kissmetrics/analytics.js-integration-kissmetrics/blob/757929883b1c5bef070ed1e569ab687849f473d8/lib/index.js#L256) upon invocation of a missing `toString` method. This broadens the initial check to discard `undefined` values as well as `null`.
