### PR TITLE
send products and revenue like server side int

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ var integration = require('@segment/analytics.js-integration');
 var is = require('is');
 var push = require('global-queue')('_kmq');
 var extend = require('@ndhoule/extend');
+var del = require('obj-case').del;
 
 /**
  * Expose `KISSmetrics` integration.
@@ -175,6 +176,9 @@ KISSmetrics.prototype.completedOrder = function(track) {
   var products = track.products();
   var timestamp = toUnixTimestamp(track.timestamp() || new Date());
   var properties = track.properties();
+  // since we send product data separately and KM doesn't serialize it anyway (shows up as '[object Object]')
+  // we're going to delete the property
+  del(properties, 'products');
   if (opts.prefixProperties) properties = prefix(event, properties);
 
   // transaction
@@ -206,6 +210,9 @@ function prefix(event, properties) {
   each(properties, function(key, val) {
     if (key === 'Billing Amount') {
       prefixed[key] = val;
+    } else if (key === 'revenue') {
+      prefixed[event + ' - ' + key] = val;
+      prefixed['Billing Amount'] = val;
     } else {
       prefixed[event + ' - ' + key] = val;
     }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@segment/analytics.js-integration": "^2.1.0",
     "component-each": "^0.2.6",
     "global-queue": "^1.0.1",
-    "is": "^3.1.0"
+    "is": "^3.1.0",
+    "obj-case": "^0.2.0"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -384,19 +384,7 @@ describe('KISSmetrics', function() {
         analytics.assert.deepEqual(window._kmq.push.args[0][0], ['record', 'completed order', {
           orderId: '12074d48',
           tax: 16,
-          total: 166,
-          // TODO: Remove this?
-          products: [{
-            sku: '40bcda73',
-            name: 'my-product',
-            price: 75,
-            quantity: 1
-          }, {
-            sku: '64346fc6',
-            name: 'other-product',
-            price: 75,
-            quantity: 1
-          }]
+          total: 166
         }]);
       });
 
@@ -423,18 +411,7 @@ describe('KISSmetrics', function() {
         analytics.assert.deepEqual(window._kmq.push.args[0][0], ['record', 'completed order', {
           'completed order - orderId': '12074d48',
           'completed order - tax': 16,
-          'completed order - total': 166,
-          'completed order - products': [{
-            sku: '40bcda73',
-            name: 'my-product',
-            price: 75,
-            quantity: 1
-          }, {
-            sku: '64346fc6',
-            name: 'other-product',
-            price: 75,
-            quantity: 1
-          }]
+          'completed order - total': 166
         }]);
       });
 


### PR DESCRIPTION
This resolves https://github.com/segment-integrations/analytics.js-integration-kissmetrics/issues/12

This PR will replicate the mapping behavior that is present on the server side.

**issue**: the `revenue` property is not being appended as `Billing Amount` like it is for server side. We are also superfluously sending `products` array even though we iterate through it and make individual and separate requests for each product in the array. Server side omits the products array from the first call to record the actual `Completed Order`. We will do the same for client side. Kissmetrics doesn't parse nested objects so they are seen in the UI as `[object Object][object Object]`. 

**solution**: map `revenue` property as `Billing Amount`. Won't remove it as its own `revenue` property albeit duplicative, since it would break reports. Remove `products` property from the first call that records the top level transaction event since we already send product info later.

@f2prateek @ladanazita 
